### PR TITLE
Update versions and dates in LSP compatibility table

### DIFF
--- a/xtext-website/documentation/340_lsp_support.md
+++ b/xtext-website/documentation/340_lsp_support.md
@@ -112,8 +112,8 @@ Currently, Xtext supports the following LSP language features:
 <table class="table table-bordered">
 	<thead>
 		<tr>
-			<th><a href="https://microsoft.github.io/language-server-protocol/specifications/specification-current/#version_3_16_0"> LSP 3.16.0 </a> (released on 2020-12-14) <br> <a href="https://github.com/eclipse/lsp4j/blob/master/CHANGELOG.md#v0100-nov-2020"> LSP4J 0.10.0 </a>(released on 2020-11-05)</th>
-			<th><a href="https://www.eclipse.org/Xtext/releasenotes.html#/releasenotes/2020/12/01/version-2-24-0"> Xtext 2.24.0 </a> <br> (released on 2020-12-01)</th>
+			<th><a href="https://microsoft.github.io/language-server-protocol/specifications/specification-current/#version_3_17_0"> LSP 3.17.0 </a> (released on 2022-10-05) <br> <a href="https://github.com/eclipse-lsp4j/lsp4j/blob/main/CHANGELOG.md#v0210-may-2023"> LSP4J 0.21.0 </a>(released on 2023-05-18)</th>
+			<th><a href="https://www.eclipse.org/Xtext/releasenotes.html#/releasenotes/2023/05/29/version-2-31-0"> Xtext 2.31.0 </a> <br> (released on 2023-05-29)</th>
 		</tr>
 	</thead>
 	<tbody>


### PR DESCRIPTION
The versions mentioned in the LSP documentation are not correct anymore, so I corrected it to prevent misunderstandings.

https://www.eclipse.org/Xtext/documentation/340_lsp_support.html