### PR TITLE
preparation for 2.36.

### DIFF
--- a/xtend-website/_posts/releasenotes/2024-08-27-version-2-36-0.md
+++ b/xtend-website/_posts/releasenotes/2024-08-27-version-2-36-0.md
@@ -1,0 +1,31 @@
+---
+layout: post
+title:  Xtend 2.36.0 Release Notes
+date:   2024-08-27
+categories: releasenotes
+published: false
+---
+
+Xtend 2.36.0 ...
+
+## Call to Action: Secure the future maintenance of Xtext & Xtend
+
+As you might have recognized, the number of people contributing to Xtext & Xtend on a regular basis has declined over the past years and so has the number of contributions. At the same time the amount of work for basic maintenance has stayed the same or even increased with the new release cadence of Java and the Eclipse simultaneous release. Briefly: The future maintenance of Xtext & especially Xtend is at risk, at least in the current form and as part of the Eclipse Simrel. If you care, please join the discussion in [https://github.com/eclipse/xtext/issues/1721](https://github.com/eclipse/xtext/issues/1721).
+
+## Relevant changes
+
+
+
+## Credits
+
+See Xtext release notes.
+
+## Fixed Issues
+
+As in every release cycle we were eagerly hunting down bugs, and reviewed and integrated plenty of contributions. For further details please refer to the following lists:
+
+* [Fixed GitHub issues](https://github.com/search?utf8=%E2%9C%93&q=is%3Aissue+milestone%3ARelease_2.36+is%3Aclosed+repo%3Aeclipse%2Fxtext+repo%3Aeclipse%2Fxtext-core+repo%3Aeclipse%2Fxtext-lib+repo%3Aeclipse%2Fxtext-extras+repo%3Aeclipse%2Fxtext-eclipse+repo%3Aeclipse%2Fxtext-idea+repo%3Aeclipse%2Fxtext-web+repo%3Aeclipse%2Fxtext-maven+repo%3Aeclipse%2Fxtext-xtend&type=Issues&ref=searchresults)
+
+* [Closed Pull Requests](https://github.com/search?utf8=%E2%9C%93&q=is%3Apr+milestone%3ARelease_2.36+is%3Aclosed+repo%3Aeclipse%2Fxtext+repo%3Aeclipse%2Fxtext-core+repo%3Aeclipse%2Fxtext-lib+repo%3Aeclipse%2Fxtext-extras+repo%3Aeclipse%2Fxtext-eclipse+repo%3Aeclipse%2Fxtext-idea+repo%3Aeclipse%2Fxtext-web+repo%3Aeclipse%2Fxtext-maven+repo%3Aeclipse%2Fxtext-xtend&type=Issues&ref=searchresults)
+
+* [Fixed Eclipse Bugzilla tickets](https://bugs.eclipse.org/bugs/buglist.cgi?bug_status=RESOLVED&bug_status=VERIFIED&bug_status=CLOSED&classification=Modeling&classification=Tools&columnlist=product%2Ccomponent%2Cassigned_to%2Cbug_status%2Cresolution%2Cshort_desc%2Cchangeddate%2Ckeywords&f0=OP&f1=OP&f3=CP&f4=CP&known_name=Xtext%202.30&list_id=16618269&product=TMF&product=Xtend&query_based_on=Xtext%202.30&query_format=advanced&status_whiteboard=v2.36&status_whiteboard_type=allwordssubstr)

--- a/xtend-website/documentation/204_activeannotations.md
+++ b/xtend-website/documentation/204_activeannotations.md
@@ -240,13 +240,13 @@ Therefore, careful testing and debugging of the processor is essential. It is be
 <dependency>
   <groupId>org.eclipse.xtend</groupId>
   <artifactId>org.eclipse.xtend.core</artifactId>
-  <version>2.35.0</version>
+  <version>2.36.0</version>
   <scope>test</scope>
 </dependency>
 <dependency>
   <groupId>org.eclipse.xtext</groupId>
   <artifactId>org.eclipse.xtext.xbase.testing</artifactId>
-  <version>2.35.0</version>
+  <version>2.36.0</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/xtend-website/download.md
+++ b/xtend-website/download.md
@@ -52,7 +52,7 @@ If you already have a project, you need to add the Xtend library:
 <dependency>
   <groupId>org.eclipse.xtend</groupId>
   <artifactId>org.eclipse.xtend.lib</artifactId>
-  <version>2.35.0</version>
+  <version>2.36.0</version>
 </dependency>
 ```
 
@@ -62,7 +62,7 @@ and the Xtend compiler plugin:
 <plugin>
   <groupId>org.eclipse.xtend</groupId>
   <artifactId>xtend-maven-plugin</artifactId>
-  <version>2.35.0</version>
+  <version>2.36.0</version>
   <executions>
     <execution>
       <goals>
@@ -90,7 +90,7 @@ plugins {
 repositories.mavenCentral()
 
 dependencies {
-  compile 'org.eclipse.xtend:org.eclipse.xtend.lib:2.35.0'
+  compile 'org.eclipse.xtend:org.eclipse.xtend.lib:2.36.0'
 }
 ```
 

--- a/xtext-website/_posts/releasenotes/2024-08-27-version-2-36-0.md
+++ b/xtext-website/_posts/releasenotes/2024-08-27-version-2-36-0.md
@@ -1,0 +1,43 @@
+---
+layout: post
+title:  Xtext 2.36.0 Release Notes
+date:   2024-08-27
+categories: releasenotes
+published: false
+---
+
+Xtext 2.36.0 ...
+
+## Call to Action: Secure the future maintenance of Xtext
+
+As you might have recognized, the number of people contributing to Xtext on a regular basis has declined over the past years and so has the number of contributions. At the same time the amount of work for basic maintenance has stayed the same or even increased with the new release cadence of Java and the Eclipse simultaneous release. Briefly: The future maintenance of Xtext is at risk, at least in the current form and as part of the Eclipse Simrel. If you care, please join the discussion in [https://github.com/eclipse/xtext/issues/1721](https://github.com/eclipse/xtext/issues/1721).
+
+## Relevant changes
+
+
+
+## Upgrades
+
+
+## Deprecations
+
+
+## Removals
+
+The long time deprecated `org.eclipse.xtext.junit4` and `org.eclipse.xtext.xbase.junit` have been removed.
+The projects `org.eclipse.xtext.testing`, `org.eclipse.xtext.ui.testing`, `org.eclipse.xtext.xbase.testing` and `org.eclipse.xtext.xbase.ui.testing` already provide replacements for the above deprecated projects.
+Note that the old base class `AbstractXtextTests` is now part of `org.eclipse.xtext.testing`.
+
+## Credits
+
+The Xtext project is thankful for the dedication of each committer and contributor. This release has been made possible by the following persons (in order of the number of contributed commits to this release).
+
+## Fixed Issues
+
+As in every release cycle we were eagerly hunting down bugs, and reviewed and integrated plenty of contributions. For further details please refer to the following lists:
+
+* [Fixed GitHub issues](https://github.com/search?utf8=%E2%9C%93&q=is%3Aissue+milestone%3ARelease_2.36+is%3Aclosed+repo%3Aeclipse%2Fxtext+repo%3Aeclipse%2Fxtext-core+repo%3Aeclipse%2Fxtext-lib+repo%3Aeclipse%2Fxtext-extras+repo%3Aeclipse%2Fxtext-eclipse+repo%3Aeclipse%2Fxtext-idea+repo%3Aeclipse%2Fxtext-web+repo%3Aeclipse%2Fxtext-maven+repo%3Aeclipse%2Fxtext-xtend&type=Issues&ref=searchresults)
+
+* [Closed Pull Requests](https://github.com/search?utf8=%E2%9C%93&q=is%3Apr+milestone%3ARelease_2.36+is%3Aclosed+repo%3Aeclipse%2Fxtext+repo%3Aeclipse%2Fxtext-core+repo%3Aeclipse%2Fxtext-lib+repo%3Aeclipse%2Fxtext-extras+repo%3Aeclipse%2Fxtext-eclipse+repo%3Aeclipse%2Fxtext-idea+repo%3Aeclipse%2Fxtext-web+repo%3Aeclipse%2Fxtext-maven+repo%3Aeclipse%2Fxtext-xtend&type=Issues&ref=searchresults)
+
+* [Fixed Eclipse Bugzilla tickets](https://bugs.eclipse.org/bugs/buglist.cgi?bug_status=RESOLVED&bug_status=VERIFIED&bug_status=CLOSED&classification=Modeling&classification=Tools&columnlist=product%2Ccomponent%2Cassigned_to%2Cbug_status%2Cresolution%2Cshort_desc%2Cchangeddate%2Ckeywords&f0=OP&f1=OP&f3=CP&f4=CP&known_name=Xtext%202.31&list_id=16618269&product=TMF&product=Xtend&query_based_on=Xtext%202.31&query_format=advanced&status_whiteboard=v2.36&status_whiteboard_type=allwordssubstr)

--- a/xtext-website/documentation/350_continuous_integration.md
+++ b/xtext-website/documentation/350_continuous_integration.md
@@ -307,6 +307,7 @@ To further speed up the p2 dependency resolution step, use the concrete build re
 
 | Xtext         | EMF           | MWE2/MWE    | Xpand       | Eclipse     | All included in |
 | ------------- | ------------- | ----------- | ----------- | ----------- | ----------- |
+| [2.36.0]({{page.upsite.xtext}}releases/2.36.0/)           | [2.38.0]({{page.upsite.eclipse}}modeling/emf/emf/builds/release/2.38.0) (2.29.0)     | [2.18.0]({{page.upsite.mwe}}releases/2.18.0/) (2.9.1) | no longer supported  | [4.33.0]({{page.upsite.eclipse}}releases/2024-09) (4.23) | [2024-09]({{page.upsite.eclipse}}releases/2024-09)|
 | [2.35.0]({{page.upsite.xtext}}releases/2.35.0/)           | [2.38.0]({{page.upsite.eclipse}}modeling/emf/emf/builds/release/2.38.0) (2.29.0)     | [2.18.0]({{page.upsite.mwe}}releases/2.18.0/) (2.9.1) | no longer supported  | [4.32.0]({{page.upsite.eclipse}}releases/2024-06) (4.23) | [2024-06]({{page.upsite.eclipse}}releases/2024-06)|
 | [2.34.0]({{page.upsite.xtext}}releases/2.34.0/)           | [2.37.0]({{page.upsite.eclipse}}modeling/emf/emf/builds/release/2.37.0) (2.29.0)     | [2.17.0]({{page.upsite.mwe}}releases/2.17.0/) (2.9.1) | no longer supported  | [4.31.0]({{page.upsite.eclipse}}releases/2024-03) (4.23) | [2024-03]({{page.upsite.eclipse}}releases/2024-03)|
 | [2.33.0]({{page.upsite.xtext}}releases/2.33.0/)           | [2.36.0]({{page.upsite.eclipse}}modeling/emf/emf/builds/release/2.36.0) (2.29.0)     | [2.16.0]({{page.upsite.mwe}}releases/2.16.0/) (2.9.1) | no longer supported  | [4.30.0]({{page.upsite.eclipse}}releases/2023-12) (4.23) | [2023-12]({{page.upsite.eclipse}}releases/2023-12)|
@@ -338,7 +339,7 @@ To further speed up the p2 dependency resolution step, use the concrete build re
 | [2.8.3]({{page.upsite.xtext}}releases/2.8.3/), [2.8.2]({{page.upsite.xtext}}releases/2.8.2/), [2.8.1]({{page.upsite.xtext}}releases/2.8.1/) | [2.11.0]({{page.upsite.emf}}2.11/core/R201506010402/) (2.10.2)  	 | [2.8.0]({{page.upsite.mwe}}releases/2.8.0/) (2.7.1) | [2.1.0]({{page.upsite.xpand}}releases/R201505260349) (1.4)  | [4.5.0]({{page.upsite.eclipse}}eclipse/updates/4.5/R-4.5-201506032000/) (3.6) | [Mars R]({{page.upsite.eclipse}}releases/mars/201506241002/)|
 | [2.7.3]({{page.upsite.xtext}}releases/maintenance/R201411190455/) | [2.10.2]({{page.upsite.emf}}2.10.x/core/S201501230452/) (2.10) | [2.7.0]({{page.upsite.mwe}}releases/R201409021051/mwe2lang/) [1.3.4]({{page.upsite.mwe}}releases/R201409021027/mwe) (2.7.0/1.2)  | [2.0.0]({{page.upsite.xpand}}releases/R201406030414) (1.4) | [4.4.2]({{page.upsite.eclipse}}eclipse/updates/4.4/R-4.4.2-201502041700) (3.6) |[Luna SR2]({{page.upsite.eclipse}}releases/luna/201502271000/)|
 
-The following is an example target platform definition for Xtext 2.35.0 and Eclipse 4.32 alias 2024-06.
+The following is an example target platform definition for Xtext 2.36.0 and Eclipse 4.33 alias 2024-09.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
@@ -347,7 +348,7 @@ The following is an example target platform definition for Xtext 2.35.0 and Ecli
 <locations>
   <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
     <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-    <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.35.0/"/>
+    <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.36.0/"/>
   </location>
   <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
     <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
@@ -356,7 +357,7 @@ The following is an example target platform definition for Xtext 2.35.0 and Ecli
     <unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
     <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
     <unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
-    <repository location="https://download.eclipse.org/releases/2024-06/"/>
+    <repository location="https://download.eclipse.org/releases/2024-09/"/>
   </location>
 </locations>
 </target>


### PR DESCRIPTION
Including the removal of old testing projects (https://github.com/eclipse/xtext/pull/3079)

See https://github.com/eclipse/xtext/issues/3061

If I understood the release date strategy correctly, the date should be fine.