### PR TITLE
Document @XbaseGenerated

### DIFF
--- a/xtend-website/_posts/releasenotes/2024-08-27-version-2-36-0.md
+++ b/xtend-website/_posts/releasenotes/2024-08-27-version-2-36-0.md
@@ -14,7 +14,7 @@ As you might have recognized, the number of people contributing to Xtext & Xtend
 
 ## Relevant changes
 
-
+* The Xtend compiler annotates the synthetic method generated for implementing dispatching for Xtend `dispatch` methods with the new annotation `@XbaseGenerated`; this way, code coverage tools like JaCoCo will ignore such Java methods when collecting code coverage. This is now the default behavior of the compiler but can be disabled with the corresponding option.
 
 ## Credits
 


### PR DESCRIPTION
This documents the `@XbaseGenerated` introduced in 2.36, which I forgot to document before in the release notes