### PR TITLE
Xbase lang reference: mention Collection Literals

### DIFF
--- a/xtend-website/_posts/releasenotes/2013-09-04-version-2-4-3.html
+++ b/xtend-website/_posts/releasenotes/2013-09-04-version-2-4-3.html
@@ -80,7 +80,7 @@ myList.filter(typeof(MyType)
 	</p>
 	<h3 id="collection_literals">Collection Literals and Arrays</h4>
 	<p>
-	Xtend now has literals for unmodifiable collections.
+	Xbase and Xtend now have literals for unmodifiable collections.
 	</p>
 <pre class="prettyprint lang-xtend linenums">
 val listOfWords = #["Hello", "Xtend"]

--- a/xtend-website/documentation/203_xtend_expressions.md
+++ b/xtend-website/documentation/203_xtend_expressions.md
@@ -124,7 +124,7 @@ val mySet = #{'Hello','World'}
 An immutable map is created like this: 
 
 ```xtend
-val myMap = #{'a' -> 1 ,'b' ->2}
+val myMap = #{'a' -> 1 ,'b' -> 2}
 ```
 
 ### Arrays {#arrays}

--- a/xtext-website/documentation/305_xbase.md
+++ b/xtext-website/documentation/305_xbase.md
@@ -558,6 +558,15 @@ The null literal is, as in Java, `null`. It is compatible to any reference type 
 
 *   `null`
 
+##### Collection Literals {#xbase-collection-literals}
+
+Immutable list, array, set and map can be created with:
+
+* `val myList = #['Hello','World'] // list`
+* `val String[] myArray = #['Hello','World'] // array, depends on target type`
+* `#{'Hello','World'} // set`
+* `#{'a' -> 1 ,'b' -> 2} // map`
+
 ##### Type Literals {#xbase-expressions-type-literal}
 
 The syntax for type literals is generally the plain name of the type, e.g. the Xbase snippet `String` is equivalent to the Java code `String.class`. Nested types use the delimiter `'.'`.


### PR DESCRIPTION
This mentions that collection literals are part of Xbase.

Collection literals were added to Xbase with https://github.com/eclipse-xtext/xtext/commit/96db5a594c3a24e72b02f3fddfb23950e3959375 and are documented for Xtend at https://eclipse.dev/Xtext/xtend/documentation/203_xtend_expressions.html#collection-literals. 